### PR TITLE
Fix Generator Script

### DIFF
--- a/scripts/generate-options.py
+++ b/scripts/generate-options.py
@@ -11,7 +11,6 @@ import frontmatter
 import verovio
 import yaml
 
-toc_file = "scripts/toc.yaml"
 
 if __name__ == "__main__":
     description = """
@@ -60,7 +59,7 @@ if __name__ == "__main__":
         options_file = frontmatter.loads(file.read())
         see_also = options_file.get('see-also', {})
 
-    with open(toc_file, 'r') as file:
+    with open(args.toc_file, 'r') as file:
         toc = yaml.full_load(file)
 
     tk = verovio.toolkit()

--- a/scripts/generate-options.py
+++ b/scripts/generate-options.py
@@ -1,19 +1,16 @@
 import argparse
-import frontmatter
 import json
-import os
-import sys
-import pprint
-import regex
-from typing import Dict, List
 import logging
+import os
+import re
+import sys
 import html
+from typing import Dict
 
+import frontmatter
 import verovio
 import yaml
 
-options_index_page = "./_book/05-toolkit-reference/04-toolkit-options.md"
-options_output = "./_includes/options/"
 toc_file = "scripts/toc.yaml"
 
 if __name__ == "__main__":
@@ -22,22 +19,15 @@ if __name__ == "__main__":
         Creates one file per option category
     """
     parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("-index", "--i", dest="options_index_page", default="_book/05-toolkit-reference/04-toolkit-options.md")
+    parser.add_argument("-output", "--o", dest="options_output", default="_includes/options/")
+    parser.add_argument("-toc", "--t", dest="toc_file", default="scripts/toc.yaml")
     verbose_group = parser.add_mutually_exclusive_group()
     verbose_group.add_argument("--verbose", "-v", action="store_true")
     verbose_group.add_argument("--debug", "-d", action="store_true")
-
     #parser.add_argument("examples", help="Path to examples.yaml file")
-
-    see_also = {}
-    with open(options_index_page, 'r') as file:
-        options_file = frontmatter.loads(file.read())
-        see_also = options_file.get('see-also', {})
-
-    toc = {}
-    with open(toc_file, 'r') as file:
-        toc: Dict = yaml.full_load(file)
-
     args = parser.parse_args()
+
     if args.debug:
         level_msg: str = "Debug"
         level = logging.DEBUG
@@ -53,6 +43,26 @@ if __name__ == "__main__":
     log = logging.getLogger(__name__)
     log.info("Running at logging level %s", level_msg)
 
+    # some basic sanity checks.
+    if not os.path.exists(args.options_index_page):
+        log.error("Could not find the options index page file.")
+        sys.exit(-1)
+
+    if not os.path.exists(args.toc_file):
+        log.error("Could not find the TOC file.")
+        sys.exit(-1)
+
+    if not os.path.exists(args.options_output):
+        log.error("The output directory does not exist.")
+        sys.exit(-1)
+
+    with open(args.options_index_page, 'r') as file:
+        options_file = frontmatter.loads(file.read())
+        see_also = options_file.get('see-also', {})
+
+    with open(toc_file, 'r') as file:
+        toc = yaml.full_load(file)
+
     tk = verovio.toolkit()
     # version of the toolkit
     log.info("Using Verovio %s", tk.getVersion())
@@ -62,18 +72,18 @@ if __name__ == "__main__":
 
     for grp_id, grp in options['groups'].items():
         # Open the file for the option group
-        f = open(options_output + grp_id + ".md", 'w')
+        f = open(os.path.join(args.options_output, f"{grp_id}.md"), 'w')
         # Table header in MD
         #f.write("| Name and parameter | Description | See also |\n")
         #f.write("|---|---|---|\n")
-        
+
         for option_id, option in grp['options'].items():
 
             # Use regex to transform JSON option names into Cmd-line option names
             # E.g, transform adjustPageHeight into --adjust-page-height
             cmd_option = option_id
-            cmd_option = regex.sub(r"(.)([A-Z][a-z]+)", r"\1-\2", cmd_option)
-            cmd_option = regex.sub(r"([a-z0-9])([A-Z])", r"\1-\2", cmd_option)
+            cmd_option = re.sub(r"(.)([A-Z][a-z]+)", r"\1-\2", cmd_option)
+            cmd_option = re.sub(r"([a-z0-9])([A-Z])", r"\1-\2", cmd_option)
             cmd_option = "--{}".format(cmd_option.lower())
 
             if option.get('shortOption'):
@@ -97,23 +107,23 @@ if __name__ == "__main__":
             if opt_type == 'bool':
                 opt_type_json_str = " <br>"
 
-            cmd_option_str = "`{} {}`".format(cmd_option, opt_type_str)
-            json_option_str = "`\"{}\": {}`".format(option_id, opt_type_json_str)
+            cmd_option_str = f"`{cmd_option} {opt_type_str}`"
+            json_option_str = f"`\"{option_id}\": {opt_type_json_str}`"
 
             # Add the default values when appropriate
             default_str = ""
             if opt_type == 'double':
-                default_str =  "<br/>(default: " + str(option['default'])
-                default_str +=  "; min: " + str(option['min'])
-                default_str +=  "; max: " + str(option['max']) + ")"
+                default_str = "<br/>(default: " + str(option['default'])
+                default_str += "; min: " + str(option['min'])
+                default_str += "; max: " + str(option['max']) + ")"
             elif opt_type == 'int' and (option['default'] != option['min'] != option['max']):
-                default_str =  "<br/>(default: " + str(option['default'])
-                default_str +=  "; min: " + str(option['min'])
-                default_str +=  "; max: " + str(option['max']) + ")"
+                default_str = "<br/>(default: " + str(option['default'])
+                default_str += "; min: " + str(option['min'])
+                default_str += "; max: " + str(option['max']) + ")"
             elif opt_type == 'std::string':
-                default_str =  "<br/>(default: \"" + option['default'] + "\")"
+                default_str = "<br/>(default: \"" + option['default'] + "\")"
             elif opt_type == 'std::string-list':
-                default_str =  "<br/>(default: \"" + option['default']
+                default_str = "<br/>(default: \"" + option['default']
                 default_str += "\"; other values: " + str(option['values']) + ")"
 
             # Add the description
@@ -124,11 +134,11 @@ if __name__ == "__main__":
             description = f"{escaped_description}{default_str}"
 
             # Check if we have an extended description in _includes/options/
-            extended_description = os.path.join(options_output, grp_id,option_id + ".md")
+            extended_description = os.path.join(args.options_output, grp_id, f"{option_id}.md")
             if os.path.exists(extended_description):
                 log.info("Include extended description %s", extended_description)
                 description += ("\n\n{{% include {} %}}".format(os.path.join("options", grp_id, option_id + ".md")))
-            
+
             # If we have one or more see-also entries in the option.md, add the links
             see_also_this = see_also.get(option_id)
             see_also_str = ""
@@ -137,7 +147,7 @@ if __name__ == "__main__":
                 see_also_links = []
                 for ref in see_also_this:
                     # Get the name of the link target from the scripts/toc.yaml file
-                    link = "[{}]({})".format(toc.get(ref, "[missing]"), ref)
+                    link = f"[{toc.get(ref, '[missing]')}]({ref})"
                     see_also_links.append(link)
                 see_also_str += " \\| ".join(see_also_links)
 

--- a/scripts/generate-options.py
+++ b/scripts/generate-options.py
@@ -7,6 +7,7 @@ import pprint
 import regex
 from typing import Dict, List
 import logging
+import html
 
 import verovio
 import yaml
@@ -116,8 +117,11 @@ if __name__ == "__main__":
                 default_str += "\"; other values: " + str(option['values']) + ")"
 
             # Add the description
-            description = option['description']
-            description = "{}{}".format(description, default_str)
+            initial_description = option['description']
+            # Some of the descriptions have XML tags which get hidden when rendered. Escape them
+            # so that they use HTML entities instead.
+            escaped_description = html.escape(initial_description)
+            description = f"{escaped_description}{default_str}"
 
             # Check if we have an extended description in _includes/options/
             extended_description = os.path.join(options_output, grp_id,option_id + ".md")


### PR DESCRIPTION
Previously some parts in the toolkit options were not showing because the angle brackets were not converted to HTML entities. This PR fixes this issue by using the built-in `html.escape` method to automatically convert characters in the toolkit descriptions to HTML entities.

It also fixes a few other things, the details are given in the commit messages.

I ran and built the site locally and it looks good to me.