### PR TITLE
Add licensing statement to title page

### DIFF
--- a/_includes/title-page.md
+++ b/_includes/title-page.md
@@ -5,3 +5,12 @@
 Generated on {{ site.time | date: "%-d %B %Y" }} from [{{ site.github.build_revision | truncate: 7, "" }}]({{ site.github.repository_url }}/commits/{{ site.github.build_revision }})
 
 DOI: [10.5448/7em6-my23](https://doi.org/10.5448/7em6-my23)
+
+This book is licensed under a
+[Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa].
+
+[![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
+
+[cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/
+[cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png
+[cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg


### PR DESCRIPTION
Copy licensing statement from README.md and add it to title page of book. Inspired by a comment by Stefan Münnich at Verovio tutorial at Music Encoding Conference 2021. Related to pull requests #18 and #19.