### PR TITLE
Improve JavaScript examples and add chapter for npm and ESM

### DIFF
--- a/_book/02-first-steps/01-getting-started.md
+++ b/_book/02-first-steps/01-getting-started.md
@@ -25,7 +25,7 @@ To start Verovio, you should add the following to your page in the head, after t
 ```html
 <script>
   document.addEventListener("DOMContentLoaded", (event) => {
-      Module.onRuntimeInitialized = () => {
+      verovio.module.onRuntimeInitialized = () => {
         let tk = new verovio.toolkit();
       }
   });
@@ -36,7 +36,7 @@ To start Verovio, you should add the following to your page in the head, after t
 
 When you refresh your page, you should still see nothing, and there should be no errors in the browser console. To help you understand what this is doing, let's start from the inside out.
 
-The line `tk = new verovio.toolkit();` creates a new instance of the Verovio toolkit. This is what we will eventually use to render the notation. However, we first need to wait until the Verovio library is fully downloaded and ready to use by your browser. The `Module.onRuntimeInitialized` line, and the `document.addEventListener` lines do just that -- they tell your browser to wait until other things have happened before trying to work with Verovio. This is a good, safe way to ensure all the requirements are met before we try to start working with Verovio.
+The line `tk = new verovio.toolkit();` creates a new instance of the Verovio toolkit. This is what we will eventually use to render the notation. However, we first need to wait until the Verovio library is fully downloaded and ready to use by your browser. The `verovio.module.onRuntimeInitialized` line, and the `document.addEventListener` lines do just that -- they tell your browser to wait until other things have happened before trying to work with Verovio. This is a good, safe way to ensure all the requirements are met before we try to start working with Verovio.
 
 ### Logging to the Console
 
@@ -64,7 +64,7 @@ At the end of this first section you should have a working web page, with a mess
     <script src="http://www.verovio.org/javascript/latest/verovio-toolkit-wasm.js" defer></script>
     <script>
       document.addEventListener("DOMContentLoaded", (event) => {
-          Module.onRuntimeInitialized = () => {
+          verovio.module.onRuntimeInitialized = () => {
             let tk = new verovio.toolkit();
             console.log("Verovio has loaded!");
           }

--- a/_book/02-first-steps/01-getting-started.md
+++ b/_book/02-first-steps/01-getting-started.md
@@ -25,7 +25,7 @@ To start Verovio, you should add the following to your page in the head, after t
 ```html
 <script>
   document.addEventListener("DOMContentLoaded", (event) => {
-      Module.onRuntimeInitialized = async _ => {
+      Module.onRuntimeInitialized = () => {
         let tk = new verovio.toolkit();
       }
   });
@@ -64,7 +64,7 @@ At the end of this first section you should have a working web page, with a mess
     <script src="http://www.verovio.org/javascript/latest/verovio-toolkit-wasm.js" defer></script>
     <script>
       document.addEventListener("DOMContentLoaded", (event) => {
-          Module.onRuntimeInitialized = async _ => {
+          Module.onRuntimeInitialized = () => {
             let tk = new verovio.toolkit();
             console.log("Verovio has loaded!");
           }

--- a/_book/02-first-steps/05-npm-usage.md
+++ b/_book/02-first-steps/05-npm-usage.md
@@ -2,7 +2,7 @@
 title: "Usage with npm"
 ---
 
-The latest stable version is available in the NPM registry. The version distributed via NPM is the WebAssembly build. It can be installed with: 
+The latest stable version is available in the *npm* registry. The version distributed via *npm* is the WebAssembly build. It can be installed with: 
 
 ```bash
 npm install verovio
@@ -33,7 +33,7 @@ verovio.module.onRuntimeInitialized = function ()
 
 ## Usage with ESM
 
-Since version 3.11.0 there is an ESM compatible version of the npm package with a modularized build of the Verovio module, that needs a slightly different setup to wait for the asynchronous Emscripten module to be ready for usage which is now [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) based instead of using the `onRuntimeInitialized` callback function.
+Since version 3.11.0 there is an ESM compatible version of the *npm* package with a modularized build of the Verovio module, that needs a slightly different setup to wait for the asynchronous Emscripten module to be ready for usage which is now [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) based instead of using the `onRuntimeInitialized` callback function.
 
  Use `.mjs` as file extension when using this directly in Node.js or set `"type": "module"` in your `package.json`.
 
@@ -66,7 +66,7 @@ const { VerovioToolkit } = require('verovio/esm');
 
 # Humdrum support
 
-Since version 3.11.0 the npm package provides an additional module with Humdrum support:
+Since version 3.11.0 the *npm* package provides an additional module with Humdrum support:
 
 ```js
 import createVerovioModule from 'verovio/wasm-hum';

--- a/_book/02-first-steps/05-npm-usage.md
+++ b/_book/02-first-steps/05-npm-usage.md
@@ -33,7 +33,7 @@ verovio.module.onRuntimeInitialized = function ()
 
 ## Usage with ESM
 
-Since version 3.11.0 there is an ESM compatible version of the *npm* package with a modularized build of the Verovio module, that needs a slightly different setup to wait for the asynchronous Emscripten module to be ready for usage which is now [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) based instead of using the `onRuntimeInitialized` callback function.
+Since version 3.11.0 there is an ESM compatible version of the *npm* package with a modularized build of the Verovio module. This is because we need to wait for the asynchronous module to be ready for usage, and this is now [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) based instead of using the `onRuntimeInitialized` callback function.
 
  Use `.mjs` as file extension when using this directly in Node.js or set `"type": "module"` in your `package.json`.
 

--- a/_book/02-first-steps/05-npm-usage.md
+++ b/_book/02-first-steps/05-npm-usage.md
@@ -1,0 +1,74 @@
+---
+title: "Usage with npm"
+---
+
+The latest stable version is available via NPM registry. The version distributed via NPM it the WebAssembly build. It can be installed with: 
+
+```bash
+npm install verovio
+```
+
+## Basic usage
+
+```javascript
+const verovio = require('verovio');
+const fs = require('fs');
+
+/* Wait for verovio to load */
+verovio.module.onRuntimeInitialized = function ()
+{
+   // create the toolkit instance
+   const vrvToolkit = new verovio.toolkit();
+   // read the MEI file
+	mei = fs.readFileSync('hello.mei');
+   // load the MEI data as string into the toolkit
+	vrvToolkit.loadData(mei.toString());
+   // render the fist page as SVG
+	svg = vrvToolkit.renderToSVG(1, {});
+   // save the SVG into a file
+	fs.writeFileSync('hello.svg', svg);
+}
+```
+
+
+## Usage with ESM
+
+Since version 3.11.0 there is an ESM compatible version of the npm package with a modularized build of the Verovio module, that needs a slightly different setup to wait for the asynchronous Emscripten module to be ready for usage which is now [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) based instead of using the `onRuntimeInitialized` callback function.
+
+ Use `.mjs` as file extension when using this directly in Node.js or set `"type": "module"` in your `package.json`.
+
+```js
+import createVerovioModule from 'verovio/wasm';
+import { VerovioToolkit } from 'verovio/esm';
+import fs from 'node:fs';
+
+createVerovioModule().then(VerovioModule => {
+   const verovioToolkit = new VerovioToolkit(VerovioModule);
+   const score = fs.readFileSync('hello.mei').toString();
+   verovioToolkit.loadData(score);
+   const data = verovioToolkit.renderToSVG(1, {});
+   console.log(data);
+});
+```
+
+This is the recommended way to use Verovio when creating a website or web app with bundlers like webpack or Vite or when using JavaScript frameworks like React or Vue.js.
+
+
+## Usage with CommonJS
+
+Alternatively this package also exports a version compatible with CommonJS
+
+```js
+const createVerovioModule = require('verovio/wasm');
+const { VerovioToolkit } = require('verovio/esm');
+```
+
+
+# Humdrum support
+
+Since version 3.11.0 the npm package provides an additional module with Humdrum support:
+
+```js
+import createVerovioModule from 'verovio/wasm-hum';
+```
+

--- a/_book/02-first-steps/05-npm-usage.md
+++ b/_book/02-first-steps/05-npm-usage.md
@@ -2,7 +2,7 @@
 title: "Usage with npm"
 ---
 
-The latest stable version is available via NPM registry. The version distributed via NPM it the WebAssembly build. It can be installed with: 
+The latest stable version is available in the NPM registry. The version distributed via NPM is the WebAssembly build. It can be installed with: 
 
 ```bash
 npm install verovio


### PR DESCRIPTION
* Fixed variable access to the emscripten module (`verovio.module` instead of `Module`). Also see https://github.com/rism-digital/verovio/pull/2937.
* Removed unnecessary async function
* Added chapter for npm and ESM examples

I'm not sure if the new chapter belongs into the "first steps" section. English is not my native language, so I would be grateful if someone would briefly proofread.