### PR TITLE
Add links to Python and JS option usage

### DIFF
--- a/_book/05-toolkit-reference/04-toolkit-options.md
+++ b/_book/05-toolkit-reference/04-toolkit-options.md
@@ -25,7 +25,7 @@ see-also:
   <label><input type="radio" name="lang" checked>Command-line parameters</label>
 </div>
 <div class="hidden-print radio-inline">
-  <label><input type="radio" name="lang">JSON objects</label>
+  <label><input type="radio" name="lang">JavaScript/Python options</label>
 </div>
 
 For the Python toolkit, options have to be passed as [stringified JSON objects](/installing-or-building-from-sources/python.html#basic-usage-of-the-toolkit). For the JavaScript toolkit, they have to be passed as [JSON objects](/first-steps/layout-options.html#passing-options-to-verovio) directly.

--- a/_book/05-toolkit-reference/04-toolkit-options.md
+++ b/_book/05-toolkit-reference/04-toolkit-options.md
@@ -25,12 +25,14 @@ see-also:
   <label><input type="radio" name="lang" checked>Command-line parameters</label>
 </div>
 <div class="hidden-print radio-inline">
-  <label><input type="radio" name="lang">JSON keys</label>
+  <label><input type="radio" name="lang">JSON objects</label>
 </div>
+
+For the Python toollkit, options have to be passed as [stringified JSON objects](/installing-or-building-from-sources/python.html#basic-usage-of-the-toolkit). For the JavaScript toolkit, the have to be passed as [JSON objects](/first-steps/layout-options.html#passing-options-to-verovio) directly.
 
 ### Base short options
 
-All of the base options are short options in the command-line version of the toolkit. Most of them are command-line options that have no direct corresponding JSON key.
+All of the base options are short options in the command-line version of the toolkit. Most of them are command-line options that have no direct corresponding JSON key / value.
 
 {% include options/0-base.md %}
 

--- a/_book/05-toolkit-reference/04-toolkit-options.md
+++ b/_book/05-toolkit-reference/04-toolkit-options.md
@@ -32,7 +32,7 @@ For the Python toolkit, options have to be passed as [stringified JSON objects](
 
 ### Base short options
 
-All of the base options are short options in the command-line version of the toolkit. Most of them are command-line options that have no direct corresponding JSON key / value.
+All of the base options are short options in the command-line version of the toolkit. Most of them are command-line only and are not used in the JavaScript or Python toolkits.
 
 {% include options/0-base.md %}
 

--- a/_book/05-toolkit-reference/04-toolkit-options.md
+++ b/_book/05-toolkit-reference/04-toolkit-options.md
@@ -28,7 +28,7 @@ see-also:
   <label><input type="radio" name="lang">JSON objects</label>
 </div>
 
-For the Python toollkit, options have to be passed as [stringified JSON objects](/installing-or-building-from-sources/python.html#basic-usage-of-the-toolkit). For the JavaScript toolkit, the have to be passed as [JSON objects](/first-steps/layout-options.html#passing-options-to-verovio) directly.
+For the Python toolkit, options have to be passed as [stringified JSON objects](/installing-or-building-from-sources/python.html#basic-usage-of-the-toolkit). For the JavaScript toolkit, they have to be passed as [JSON objects](/first-steps/layout-options.html#passing-options-to-verovio) directly.
 
 ### Base short options
 


### PR DESCRIPTION
It is meant to clarify that the option object has to be stringified in Python but not in JS