### PR TITLE
Integrate the tutorials from ESS

### DIFF
--- a/_book/03-interactive-notation/00-index.md
+++ b/_book/03-interactive-notation/00-index.md
@@ -1,6 +1,8 @@
 ---
 chapter-title: "Tutorial 2: Interactive notation"
-title: "Introduction"
+link_to_section: true
+layout: redirect
+redirect_to: "css-and-svg.html"
 ---
 
 [in preparation]

--- a/_book/03-interactive-notation/01-css-and-svg.md
+++ b/_book/03-interactive-notation/01-css-and-svg.md
@@ -1,0 +1,154 @@
+---
+title: "CSS and SVG"
+---
+
+### Understanding the structure of the SVG
+
+The SVG produced by Verovio can be manipulated further. In this tutorial, you are going to use CSS to highlight some content of the output.
+
+One key feature of Verovio is that it preserves the structure of the MEI in the SVG output. For example, a chord with two notes encoded in MEI:
+
+```xml
+<chord xml:id="c1">
+  <note/>
+  <note/>
+</chord>
+```
+
+will have a the following structure in the SVG:
+
+```xml
+<g class="chord" id="c1">
+  <g class="note"/>
+  <g class="note"/>
+</g>
+```
+
+You will notice that not only the tree structure is preserved, but also that MEI element names are passed as `@class` attribute values in the SVG elements, as well as the `@xml:id` of the MEI element as `@id` in the SVG.
+
+Thanks to this, and because SVG can be styled with CSS, it is straightforward to modify the appearance of elements and their content.
+
+Modifying the appearance can be done with a CSS file, or programmatically.
+
+### Applying CSS to the SVG
+
+In the CSS file you need to create rules to be applied to the SVG `<g>` elements - simply `g` in CSS - together with the class selector corresponding to the MEI element name. For example, `g.tempo` to modifying MEI `<tempo>` elements.
+
+```
+g.tempo {
+  // ... some CSS properties
+}
+```
+
+To modify the color, you need to change the `fill` property, and - in some cases - also the `color` property. The CSS rule will look like:
+
+```
+{
+  fill: crimson;
+  color: crimson;
+}
+```
+
+You can also select elements based on their hierarchy. For example, you can select `<artic>` within `<chord>` with:
+
+```
+g.chord g.artic {
+}
+```
+
+CSS can be animated, for example by making the colors pulsing. You need to specify an animation name with a duration and an iteration count together with corresponding key frames:
+
+```
+{
+  animation-name: pulse;
+  animation-duration: 1.0s;
+  animation-iteration-count: infinite;
+}
+
+@keyframes pulse {
+  0%   { fill: orange; }
+  50%  { fill: brown; }
+  100% { fill: orange; }
+}
+```
+
+CSS can also be used to change the opacity of an element. The opacity value can range from 0.0 (transparent) to 1.0 (normal default value).
+
+### Adjusting the style programmatically
+
+In applications, it is often useful to modify the CSS programmatically, for example in response to some user interactions.
+
+To do so, elements can be accessed by element and class name in the same way as with CSS. For example, for retrieving all rests, you can do:
+
+```js
+let rests = document.querySelectorAll('g.rest');
+```
+
+You can then loop through the list of rests with:
+
+```js
+for (let rest of rests) {
+    // you have now access to the rest one by one and can modify their style
+}
+```
+
+To modify the style of an element, you can assign the desired value to the corresponding key. For example, in order to change the color (fill) or a rest (element), you need to do:
+
+```js
+rest.style.fill = "dodgerblue";
+```
+
+#### Using custom data-* attributes
+
+The attributes in the SVG `<g>` elements corresponding to the MEI elements is not limited to the `@class` carrying the MEI element name and the MEI `@xml:id` passed as `@id`. Verovio also passed MEI `@type` values as additional `@class` in the SVG.
+
+However, in many cases, applications need to have access at other attribute values. To do so, one can use the `svgAdditionalAttribute` option to specify which attributes needs to be made available directly in the SVG output. For example, for making the note pitch name and the note octave accessible, you will need to add the following option value:
+
+```json
+{
+  svgAdditionalAttribute: ["note@pname", "note@oct"]
+}
+```
+
+With this option, each `g.note` element in the SVG will also have a `data-pname` and a `data-oct` attritute carrying the original MEI attribute value. For example, and note in MEI and the corresponding SVG element will be:
+
+```xml
+<note pname="c" oct="5"/>
+```
+
+```xml
+<g class="note" data-pname="c" data-oct="5"/>
+```
+
+This can be used in the query selector to restrict the matches to elements having specific attribute values. For example, for selecting the C5 notes, you would do:
+
+```js
+let c5s = document.querySelectorAll('g[data-pname="c"][data-oct="5"]');
+```
+
+#### Accessing MEI attribute values programmatically
+
+Custom data-* attributes are quite straightforward and easy to use. However, selectors have limitations, and it is not always possible to know in advance all the attributes that one need to have available in the SVG. Furthermore, if the list of attributes becomes too long, the SVG might become overloaded.
+
+In such cases, it is possible and preferable to access them programmatically. This can be done through the `getElementAttr()` toolkit method that gives access to all the MEI attributes of a given element, including attributes not currently supported or not used by Verovio. It takes an `@id` as parameter and returns a JSON object with all the attributes. For example, if you currently have `rest` variable holding the SVG node corresponding to an MEI rest, you can retrieve all the attributes by passing  the `rest.id` value to the method:
+
+```js
+let attr = tk.getElementAttr(rest.id);
+```
+
+You can then look at any attributes specifically in the JSON object returned, for example `attr.dur` for the MEI `@dur` of the rest:
+
+```js
+if (attr.dur && attr.dur == "1") {
+  // This is a whole note rest 
+}
+```
+
+### Full example
+
+Open [this example](/tutorials/css-and-svg.html){:target="_blank"} in a new window.
+
+```html
+{% include tutorials/css-and-svg.html %}
+```
+

--- a/_book/03-interactive-notation/01-css-and-svg.md
+++ b/_book/03-interactive-notation/01-css-and-svg.md
@@ -110,7 +110,7 @@ However, in many cases, applications need to have access at other attribute valu
 }
 ```
 
-With this option, each `g.note` element in the SVG will also have a `data-pname` and a `data-oct` attritute carrying the original MEI attribute value. For example, and note in MEI and the corresponding SVG element will be:
+With this option, each `g.note` element in the SVG will also have a `data-pname` and a `data-oct` attribute carrying the original MEI attribute value. For example, a note in MEI and the corresponding SVG element will be:
 
 ```xml
 <note pname="c" oct="5"/>

--- a/_book/03-interactive-notation/01-css-and-svg.md
+++ b/_book/03-interactive-notation/01-css-and-svg.md
@@ -102,7 +102,7 @@ rest.style.fill = "dodgerblue";
 
 The attributes in the SVG `<g>` elements corresponding to the MEI elements is not limited to the `@class` carrying the MEI element name and the MEI `@xml:id` passed as `@id`. Verovio also passed MEI `@type` values as additional `@class` in the SVG.
 
-However, in many cases, applications need to have access at other attribute values. To do so, one can use the `svgAdditionalAttribute` option to specify which attributes needs to be made available directly in the SVG output. For example, for making the note pitch name and the note octave accessible, you will need to add the following option value:
+However, in many cases, applications need to have access at other attribute values. To do so, one can use the `svgAdditionalAttribute` option to specify which attributes can be made available in the SVG output. For example, for making the note pitch name and the note octave accessible, you can add the following option values to Verovio's `setOptions()` method:
 
 ```json
 {

--- a/_book/03-interactive-notation/01-css-and-svg.md
+++ b/_book/03-interactive-notation/01-css-and-svg.md
@@ -26,7 +26,7 @@ will have a the following structure in the SVG:
 
 You will notice that both the tree structure is preserved and that the MEI element names are passed as `@class` attribute values in the SVG elements, as well as the `@xml:id` of the MEI element as `@id` in the SVG.
 
-Thanks to this, and because SVG can be styled with CSS, it is straightforward to modify the appearance of elements and their content.
+Since SVG can be styled with CSS, it is straightforward to modify the appearance of elements and their contents.
 
 Modifying the appearance can be done with a CSS file, or programmatically.
 

--- a/_book/03-interactive-notation/01-css-and-svg.md
+++ b/_book/03-interactive-notation/01-css-and-svg.md
@@ -100,7 +100,7 @@ rest.style.fill = "dodgerblue";
 
 #### Using custom data-* attributes
 
-The attributes in the SVG `<g>` elements corresponding to the MEI elements is not limited to the `@class` carrying the MEI element name and the MEI `@xml:id` passed as `@id`. Verovio also passed MEI `@type` values as additional `@class` in the SVG.
+The attributes in the SVG `<g>` elements corresponding to the MEI elements is not limited to the `@class` carrying the MEI element name and the MEI `@xml:id` passed as `@id`. Verovio also passes MEI `@type` values as additional `@class` in the SVG.
 
 However, in many cases, applications need to have access at other attribute values. To do so, one can use the `svgAdditionalAttribute` option to specify which attributes can be made available in the SVG output. For example, for making the note pitch name and the note octave accessible, you can add the following option values to Verovio's `setOptions()` method:
 

--- a/_book/03-interactive-notation/01-css-and-svg.md
+++ b/_book/03-interactive-notation/01-css-and-svg.md
@@ -130,7 +130,10 @@ let c5s = document.querySelectorAll('g[data-pname="c"][data-oct="5"]');
 
 Custom `data-*` attributes are straightforward and easy to use with CSS selectors. However, selectors can have some limits, and it is not always possible to know in advance all the attributes that needed in the SVG. Furthermore, if the list of attributes becomes too long, the SVG might become overloaded.
 
-In such cases, it is possible and preferable to access them programmatically. This can be done through the `getElementAttr()` toolkit method that gives access to all the MEI attributes of a given element, including attributes not currently supported or not used by Verovio. It takes an `@id` as parameter and returns a JSON object with all the attributes. For example, if you currently have `rest` variable holding the SVG node corresponding to an MEI rest, you can retrieve all the attributes by passing  the `rest.id` value to the method:
+In this case, it is possible and preferable to access them programmatically with JavaScript. This can be done through the `getElementAttr()` toolkit method that gives access to all the MEI attributes of a given element, including attributes not currently supported or not used by Verovio. It takes an `xml:id` value as the input parameter and returns a JSON object with all the attributes for that element from the MEI encoding. For example, given this MEI:
+
+```xml
+<rest xml:id="r123" dur="4" dots="1">
 
 ```js
 let attr = tk.getElementAttr(rest.id);

--- a/_book/03-interactive-notation/01-css-and-svg.md
+++ b/_book/03-interactive-notation/01-css-and-svg.md
@@ -32,7 +32,7 @@ Modifying the appearance can be done with a CSS file, or programmatically.
 
 ### Applying CSS to the SVG
 
-In the CSS file you need to create rules to be applied to the SVG `<g>` elements - simply `g` in CSS - together with the class selector corresponding to the MEI element name. For example, `g.tempo` to modifying MEI `<tempo>` elements.
+In the CSS file you need to create rules to be applied to the SVG `<g>` elements - simply `g` in CSS - together with the class selector corresponding to the MEI element name. For example, `g.tempo` modifies MEI `<tempo>` elements.
 
 ```
 g.tempo {

--- a/_book/03-interactive-notation/01-css-and-svg.md
+++ b/_book/03-interactive-notation/01-css-and-svg.md
@@ -128,7 +128,7 @@ let c5s = document.querySelectorAll('g[data-pname="c"][data-oct="5"]');
 
 #### Accessing MEI attribute values programmatically
 
-Custom data-* attributes are quite straightforward and easy to use. However, selectors have limitations, and it is not always possible to know in advance all the attributes that one need to have available in the SVG. Furthermore, if the list of attributes becomes too long, the SVG might become overloaded.
+Custom `data-*` attributes are straightforward and easy to use with CSS selectors. However, selectors can have some limits, and it is not always possible to know in advance all the attributes that needed in the SVG. Furthermore, if the list of attributes becomes too long, the SVG might become overloaded.
 
 In such cases, it is possible and preferable to access them programmatically. This can be done through the `getElementAttr()` toolkit method that gives access to all the MEI attributes of a given element, including attributes not currently supported or not used by Verovio. It takes an `@id` as parameter and returns a JSON object with all the attributes. For example, if you currently have `rest` variable holding the SVG node corresponding to an MEI rest, you can retrieve all the attributes by passing  the `rest.id` value to the method:
 

--- a/_book/03-interactive-notation/01-css-and-svg.md
+++ b/_book/03-interactive-notation/01-css-and-svg.md
@@ -24,7 +24,7 @@ will have a the following structure in the SVG:
 </g>
 ```
 
-You will notice that not only the tree structure is preserved, but also that MEI element names are passed as `@class` attribute values in the SVG elements, as well as the `@xml:id` of the MEI element as `@id` in the SVG.
+You will notice that both the tree structure is preserved and that the MEI element names are passed as `@class` attribute values in the SVG elements, as well as the `@xml:id` of the MEI element as `@id` in the SVG.
 
 Thanks to this, and because SVG can be styled with CSS, it is straightforward to modify the appearance of elements and their content.
 

--- a/_book/03-interactive-notation/01-css-and-svg.md
+++ b/_book/03-interactive-notation/01-css-and-svg.md
@@ -136,7 +136,7 @@ In this case, it is possible and preferable to access them programmatically with
 <rest xml:id="r123" dur="4" dots="1">
 
 ```js
-let attr = tk.getElementAttr(rest.id);
+let attr = tk.getElementAttr("r123");
 ```
 
 You can then look at any attributes specifically in the JSON object returned, for example `attr.dur` for the MEI `@dur` of the rest:

--- a/_book/03-interactive-notation/01-working-with-css-and-svg.md
+++ b/_book/03-interactive-notation/01-working-with-css-and-svg.md
@@ -1,5 +1,0 @@
----
-title: "Working with CSS and SVG"
----
-
-[in preparation]

--- a/_book/03-interactive-notation/02-encoding-formats.md
+++ b/_book/03-interactive-notation/02-encoding-formats.md
@@ -2,7 +2,7 @@
 title: "Encoding formats"
 ---
 
-The primary notation encoding format used with Verovio is MEI; however, Verovio supports conversion from a number of other formats, including MusicXML. In this tutorial we will look at how we can get Verovio to convert a compressed  MusicXML to MEI.
+The primary notation encoding format used with Verovio is MEI; however, Verovio supports conversion from a number of other formats, including MusicXML. In this tutorial we will look at how we can get Verovio to convert a compressed MusicXML file to MEI.
  
 ### Saving as MEI
 

--- a/_book/03-interactive-notation/02-encoding-formats.md
+++ b/_book/03-interactive-notation/02-encoding-formats.md
@@ -1,0 +1,52 @@
+---
+title: "Encoding formats"
+---
+
+The primary notation encoding format used with Verovio is MEI; however, Verovio supports conversion from a number of other formats, including MusicXML. In this tutorial we will look at how we can get Verovio to convert a compressed  MusicXML to MEI.
+ 
+### Saving as MEI
+
+When loading a MusicXML file into Verovio, it converts this internally into MEI, which we will be able to export as MEI.
+
+To do this, and to make our lives easier, we will use a JavaScript library that helps us save a file. In the `<head>` section of your file, add the following `<script>` tag:
+
+```html
+<script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.0/FileSaver.min.js"></script>
+```
+
+To download the MEI file, we will add a button to our page that will trigger a save of the MEI content from Verovio. Just like in previous tutorials, add a "click" handler for a button:
+
+```js
+document.getElementById("saveMEI").addEventListener("click", (event) => {
+    let meiContent = tk.getMEI();
+    var myBlob = new Blob([meiContent], {type: "application/xml"});
+    saveAs(myBlob, "meifile.mei"); 
+});
+```
+
+That is, we get the button element (`id="saveMEI"`), and then tell the button what to do when it is clicked. To get the MEI output we can use the `getMEI()` method on the toolkit. This will return a formatted string containing the MEI XML output. 
+
+Then we do a few JavaScript things to get the download to work. First we create a new "Blob", which is just a wrapper around some arbitrary data. Then we call the `saveAs` function from the FileSaver.js library we loaded earlier. 
+
+### Compressed MusicXML
+
+You may not be aware of it, but there are actually two forms of MusicXML files! Typically, those that end with `.xml` or `.musicxml` are "plain" XML files, and we can load them directly. Here we are going to load a "compressed" MusicXML file, normally ending with a `.mxl` extension. These files are just ZIP files, but have a fixed file-and-folder structure within them. Verovio supports loading these types of files as well, but with a bit of special handling needed.
+
+To display this we follow the same methods as loading previous files, except for two main differences:
+
+ - We use `response.arrayBuffer()` instead of `response.text()` to read the initial response;
+ - We use Verovio's `loadZipDataBuffer` toolkit method, instead of the regular `loadData` method.
+
+### Wrapping up
+
+With Verovio you can easily convert MusicXML files, in both compressed and uncompressed formats, to MEI. There are a number of other formats that Verovio supports as well, but some need to be specially enabled if you wish to use them.
+
+Check out the chapter on [Input formats](https://book.verovio.org/toolkit-reference/input-formats.html) in the Verovio book for more details.
+
+### Full example
+
+Open [this example](/tutorials/musicxml.html){:target="_blank"} in a new window.
+
+```html
+{% include tutorials/musicxml.html %}
+```

--- a/_book/03-interactive-notation/02-xpath-queries.md
+++ b/_book/03-interactive-notation/02-xpath-queries.md
@@ -1,5 +1,0 @@
----
-title: "XPath queries"
----
-
-[in preparation]

--- a/_book/03-interactive-notation/03-playing-midi.md
+++ b/_book/03-interactive-notation/03-playing-midi.md
@@ -1,0 +1,134 @@
+---
+title: "Playing the MIDI output"
+---
+
+Verovio can produce basic MIDI files and this feature is also available in the JavaScript toolkit. It can be used to play an MEI file directly in the browser as demonstrated in this tutorial.
+
+### Add a MIDI player
+
+MIDI playback is not built-in to the web browser, nor available directly in Verovio. This means that we need to add a MIDI player to our page. For this tutorial we are going to use [MIDIjs](http://www.midijs.net/). You need to add a `<script>` tag with the following `src` attribute:
+
+```
+https://www.midijs.net/lib/midi.js
+```
+
+We also need buttons to handle the start and stop playing events. Add them a the top of the body above the notation div:
+
+```html
+  <button id="playMIDI">Play</button>
+  <button id="stopMIDI">Stop</button>
+```
+
+You also need to make sure they do something when clicking on them:
+
+```js
+document.getElementById("playMIDI").addEventListener("click", playMIDIHandler);
+document.getElementById("stopMIDI").addEventListener("click", stopMIDIHandler);
+```
+
+We now need to define what actually happens when the user clicks. That is, defining the `playMIDIHandler` and `stopMIDIHandler` functions we just bound to the button event listeners. We can scaffold them with:
+
+```js
+const playMIDIHandler = function () {
+  // do something to start playing
+}
+
+const stopMIDIHandler = function () {
+  // do something to stop playing
+}
+```
+
+At this stage they do nothing. To start playing, we need to get the MIDI data produced by Verovio and pass it to the player. We will use the Verovio `renderToMIDI` method that returns a MIDI file encoded as a base64 string, which we can pass to MIDIjs:
+
+```js
+// Get the MIDI file from the Verovio toolkit
+let base64midi = tk.renderToMIDI();
+// Add the data URL prefixes describing the content
+let midiString = 'data:audio/midi;base64,' + base64midi;
+// Pass it to play to MIDIjs
+MIDIjs.play(midiString);
+```
+
+Stop playing is even simpler. You only need to tell MIDIjs to do so:
+
+```js
+MIDIjs.stop();
+```
+
+The examples above will be followed to write the body of the `playMIDIHandler` and `stopMIDIHandler` functions.
+
+### Highlighting the notes while playing
+
+The MIDIjs player provides us with a callback function that gives us the current playback time. We can use this for highlighting the notes as the MIDI file plays! Each time the callback function is called, we can highlight the notes that are currently played, and automatically move to the next page if necessary.
+
+You need to start by defining a callback function, similar to the button event we wrote earlier:
+
+```js
+const midiHightlightingHandler = function (event) {
+  // Do something everytime the callback function is called
+}
+```
+
+You will notice that the function has an `event` parameter that will give us information about the current event. What we need to use is `event.time` that indicates the current playing time in seconds. We are going to use this and the Verovio `getElementsAtTime` method that retrieves all elements being played at a given time in order to obtain the list of notes being played:
+
+```js
+// Get elements at a time in milliseconds (time from the player is in seconds)
+let currentElements = tk.getElementsAtTime(event.time * 1000);
+```
+
+Now we should check that a page number was set. This is just to ensure we do not end up in an undefined state; for example, if the file is not loaded, or if we asked for elements that do not exist. If the page is 0, something went wrong and we should return:
+
+```js
+if (currentElements.page == 0) return;
+```
+
+We should also check that we are currently rendering the correct page. If not, we should load it first:
+
+```js
+if (currentElements.page != currentPage) {
+  currentPage = currentElements.page;
+  document.getElementById("notation").innerHTML = tk.renderToSVG(currentPage);
+}
+```
+
+To do the highlighting of the notes we are going to use a CSS rule to be defined in the `style.css` file. A simple way to do it is to add a class `playing` to be applied to `g.notes` and that changes the color:
+
+```css
+g.note.playing {
+  fill: crimson;
+}
+```
+
+Now we can actually highlight the notes. To do so, we are going to loop over the list of notes listed in `currentElements` and simply add the `playing` class to them:
+
+```js
+// Get all notes playing and set the class
+for (note of currentElements.notes) {
+  let noteElement = document.getElementById(note);
+  if (noteElement) noteElement.classList.add("playing");
+}
+```
+
+Finally, we need to bind the MIDIjs player with the callback function we have defined. This will be done with:
+
+```js
+MIDIjs.player_callback = midiHightlightingHandler;
+```
+
+This should not work! However, if it does, you will notice that we also need to de-highlight the notes that are not played anymore, otherwise they will stay highlighted. This should be done at the beginning of the `midiHightlightingHandler` callback function by removing the `playing` class to the notes that currently have it:
+
+```js
+// Remove the attribute 'playing' of all notes previously playing
+let playingNotes = document.querySelectorAll('g.note.playing');
+for (let playingNote of playingNotes) playingNote.classList.remove("playing");
+```
+
+The code above needs to be placed within the body of the `midiHighlightingHandler` function. 
+
+### Full example
+
+Open [this example](/tutorials/midi.html){:target="_blank"} in a new window.
+
+```html
+{% include tutorials/midi.html %}
+```

--- a/_book/03-interactive-notation/03-working-with-midi.md
+++ b/_book/03-interactive-notation/03-working-with-midi.md
@@ -1,5 +1,0 @@
----
-title: "Working with MIDI"
----
-
-[in preparation]

--- a/_book/03-interactive-notation/04-content-selection.md
+++ b/_book/03-interactive-notation/04-content-selection.md
@@ -1,0 +1,35 @@
+---
+title: "Score content selection"
+---
+
+Verovio can extract segments of a score and display only these segments. This can be useful if you have a larger score and want to display a segment in a webpage to highlight a particular segment or portion. This can also be combined with the techniques from the previous tutorials, so you can also highlight or even play back these segments using MIDI. 
+
+### Selecting parts of a score
+
+Verovio has a `select` method available on the toolkit. This method takes a JSON object where you can specify a range of measures in the format "[first]-[last]". The selection syntax is based on a subset of the `measureRange` syntax from the [Enhancing Music Notation Addressability API](https://github.com/music-addressability/ema/blob/master/docs/api.md). The difference is that Verovio only supports a single measure range. For example:
+
+```js
+tk.select({measureRange: "1-10"});
+```
+
+Once the measures have been selected, calls to render the score to SVG will render only that selected portion. Importantly, it will also reduce the number of "pages" that are available to only the number that are needed to represent the selection.
+
+You can clear a selection by passing in an empty JSON Object:
+
+```js
+tk.select({});
+```
+
+You can also select the entire score by using `start` and `end`:
+
+```js
+tk.select({measureRange: "start-end"});
+```
+
+### Full example
+
+Open [this example](/tutorials/content-selection.html){:target="_blank"} in a new window.
+
+```html
+{% include tutorials/content-selection.html %}
+```

--- a/_book/03-interactive-notation/05-editorial-markup.md
+++ b/_book/03-interactive-notation/05-editorial-markup.md
@@ -1,0 +1,124 @@
+---
+title: "Interacting with editorial markup"
+---
+
+MEI has a feature that lets us encode variant "readings" of a musical text. These readings may come from different sources of the same piece. A common type of alternate reading is a "contrafactum", or alternate text. Typically this might occur between a Latin sacred text and a secular text in a vernacular, such as English, both set to the same music.
+
+Verovio supports the selection of variant readings encoded with MEI `<app>`, containing `<lem>` and `<rdg>` elements. Only one variant can be displayed at a time, and this is selected when the file is loaded. By default, Verovio selects the `<lem>` (or the first `<rdg>` if no `<lem>` is provided).
+
+In this example we are going to create a basic interface to switch between variants by applying XPath queries for selecting specific readings, and then highlight the editorial markup in different colours. The MEI file we will use for this purpose comes from the Marenzio edition:
+
+```
+https://raw.githubusercontent.com/marenzio/marenzio.github.io/master/mei/M-04-6/M_04_6_02_Di_nettare_amoroso_ebro_la_mente.mei
+```
+
+### Selection with an xpath query
+
+The first thing we need is a variable to store the XPath queries. This must be an array, but we can start with an empty one, which applies the default behaviour:
+
+```js
+let appXPath = [];
+```
+
+Since Verovio selects the elements to be displayed when loading the file, we need to define a `loadFile()` function that applies the options, loads the file into Verovio, and renders it:
+
+```js
+// A function that loads a file
+function loadFile() {
+  fetch("https://raw.githubusercontent.com/marenzio/marenzio.github.io/master/mei/M-04-6/M_04_6_02_Di_nettare_amoroso_ebro_la_mente.mei")
+    .then((response) => response.text())
+    .then((meiXML) => {
+      tk.setOptions({
+        pageWidth: document.body.clientWidth,
+        pageHeight: document.body.clientHeight,
+        scale: 50,
+        scaleToPageSize: true,
+        appXPathQuery: appXPath
+      });
+      tk.loadData(meiXML);
+      notationElement.innerHTML = tk.renderToSVG(currentPage);
+    });
+}
+```
+
+To load, or reload, the file we can now call the function:
+
+```js
+loadFile();
+```
+
+In the CSS file we also have defined two rules:
+
+```css
+g.lem {
+  fill: darkcyan;
+}
+g.rdg {
+  fill: crimson;
+}
+```
+
+At this stage, because we have a `editorial-markup.css` with some rule highlighting for `lem` and `rdg` classes, the default `<lem>` should appear highlighted.
+
+### Switching between readings
+
+To switch between the original and a reading (an English contrafactum text, in this case), we add two buttons, with two handlers that bind to the button event listeners:
+
+```html
+<button id="original">Original</button>
+<button id="contrafactum">Contrafactum</button>
+```
+
+```js
+const originalHandler = function () {
+  // Do something to render the original
+}
+
+const contrafactumHandler = function () {
+ // Do something to render the contrafactum
+}
+
+document.getElementById("original").addEventListener("click", originalHandler);
+document.getElementById("contrafactum").addEventListener("click", contrafactumHandler);
+```
+
+The file example we are using has some readings encoded as follows:
+
+```xml
+<app>
+  <lem source="Italian">
+    <verse>
+      <syl>Di</syl>
+    </verse>
+  </lem>
+  <rdg source="English">
+    <verse>
+      <syl>When</syl>
+    </verse>
+  </rdg>
+</app>
+```
+
+To select the "English" reading (i.e., in the `contrafactumHandler`), we can write an xPath query selecting `<rdg>` elements with the corresponding `@source` value, in this case "English", and then reload the file:
+
+```js
+appXPath = ["./rdg[@source='English']"];
+loadFile();
+```
+
+For the original, we can reset Verovio by passing in an empty `appXPath` array:
+
+```js
+appXPath = [];
+loadFile();
+```
+
+When switching between the views you will notice that the colour of the text differs between the original `<lem>` and the English `<rdg>`. 
+
+### Full example
+
+Open [this example](/tutorials/editorial-markup.html){:target="_blank"} in a new window.
+
+```html
+{% include tutorials/editorial-markup.html %}
+```

--- a/_includes/tutorials/content-selection.html
+++ b/_includes/tutorials/content-selection.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title>Select an excerpt of a score interactively</title>
+        <script src="https://www.verovio.org/javascript/develop/verovio-toolkit-wasm.js" defer></script>
+    </head>
+    <body>
+        <label>Select: </label>
+        <input id="start" type="text" placeholder="from..." />
+        <input id="end" type="text" placeholder="...to" />
+        <button id="applySelection">Apply</button>
+        <button id="prevPage">Previous page</button>
+        <button id="nextPage">Next page</button>
+        <div id="notation"></div>
+        <script>
+            /** 
+             Load Verovio
+            **/
+            document.addEventListener("DOMContentLoaded", (event) => {
+                verovio.module.onRuntimeInitialized = function () {
+                    // This line initializes the Verovio toolkit
+                    const tk = new verovio.toolkit();
+
+                    tk.setOptions({
+                        pageWidth: document.body.clientWidth,
+                        pageHeight: document.body.clientHeight,
+                        scale: 75,
+                        scaleToPageSize: true,
+                    });
+
+                    // Keep a variable to the notation div id
+                    let notationElement = document.getElementById("notation");
+
+                    // The current page, which will change when playing through the piece
+                    let currentPage = 1;
+
+                    /**
+                     The handler to apply the selection
+                    **/
+                    const applySelectionHandler = function () {
+                        let start = document.getElementById("start").value;
+                        if (start === '') start = "start";
+                        let end = document.getElementById("end").value;
+                        if (end === '') end = "end";
+                        let range = `${start}-${end}`;
+                        tk.select({measureRange: range});
+                        tk.redoLayout();
+                        notationElement.innerHTML = tk.renderToSVG(currentPage);
+                    }
+
+                    /**
+                        Wire up the button to actually work.
+                    */
+                    const nextPageHandler = function () {
+                        currentPage = Math.min(currentPage + 1, tk.getPageCount());
+                        notationElement.innerHTML = tk.renderToSVG(currentPage);
+                    }
+
+                    const prevPageHandler = function () {
+                        currentPage = Math.max(currentPage - 1, 1);
+                        notationElement.innerHTML = tk.renderToSVG(currentPage);
+                    }
+
+                    /**
+                        Wire up the buttons to actually work.
+                    */
+                    document.getElementById("nextPage").addEventListener("click", nextPageHandler);
+                    document.getElementById("prevPage").addEventListener("click", prevPageHandler);
+                    document.getElementById("applySelection").addEventListener("click", applySelectionHandler);
+
+                    // This line fetches the MEI file we want to render...
+                    fetch("https://www.verovio.org/examples/downloads/Schubert_Lindenbaum.mei")
+                        // ... then receives the response and "unpacks" the MEI from it
+                        .then((response) => response.text())
+                        .then((meiXML) => {
+                            // ... then we can load the data into Verovio ...
+                            tk.loadData(meiXML);
+                            // ... and generate the SVG for the first page ...
+                            let svg = tk.renderToSVG(1);
+                            // ... and finally gets the <div> element with the ID we specified, 
+                            // and sets the content (innerHTML) to the SVG that we just generated.
+                            notationElement.innerHTML = svg;
+                        });
+                }
+            });
+        </script>
+    </body>
+</html>

--- a/_includes/tutorials/css-and-svg.html
+++ b/_includes/tutorials/css-and-svg.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title>Understanding the structure of the SVG</title>
+        <!-- A stylesheet for modifying the appearance of the output -->
+        <link href="solution.css" rel="stylesheet" type="text/css" />
+        <!-- Verovio -->
+        <script src="https://www.verovio.org/javascript/develop/verovio-toolkit-wasm.js" defer></script>
+    </head>
+    <body>
+        <script>
+            document.addEventListener("DOMContentLoaded", (event) => {
+                verovio.module.onRuntimeInitialized = function () {
+                    // This line initializes the Verovio toolkit
+                    const tk = new verovio.toolkit();
+
+                    let zoom = 80;
+                    let pageHeight = document.body.clientHeight * 100 / zoom;
+                    let pageWidth = document.body.clientWidth * 100 / zoom;
+
+                    options = {
+                        pageHeight: pageHeight,
+                        pageWidth: pageWidth,
+                        scale: zoom,
+                        // Add an option to pass note@pname and note@oct as svg @data-*
+                        svgAdditionalAttribute: ["note@pname", "note@oct"]
+                    };
+                    tk.setOptions(options);
+
+                    // This line fetches the MEI file we want to render...
+                    fetch('https://www.verovio.org/examples/downloads/Schubert_Lindenbaum.mei')
+                        // ... then receives the response and "unpacks" the MEI from it
+                        .then((response) => response.text())
+                        .then((mei) => {
+                            // ... then we can load the data into Verovio ...
+                            tk.loadData(mei);
+                            // ... and generate the SVG for the first page
+                            let svg = tk.renderToSVG(1);
+                            // ... and finally gets the <div> element with the ID we specified, 
+                            // and sets the content (innerHTML) to the SVG that we just generated.
+                            document.getElementById("notation").innerHTML = svg;
+
+                            // Get all the rests by selecting <g> with attribute class 'rest' ...
+                            let rests = document.querySelectorAll('g.rest');
+                            // ... and change their color by setting their style.fill value
+                            for (let rest of rests) {
+                                rest.style.fill = "dodgerblue";
+                            }
+
+                            // Get all the notes with @pname="c" and @oct="5" and change their color
+                            let c5s = document.querySelectorAll('g[data-pname="c"][data-oct="5"]');
+                            for (let c5 of c5s) {
+                                c5.style.fill = "aqua";
+                            }
+
+                            // Get all the verses ...
+                            let verses = document.querySelectorAll('g.verse');
+                            // ... and use the 'getElementAttr()' to retrieve all attributes ...
+                            for (let verse of verses) {
+                                let attr = tk.getElementAttr(verse.id);
+                                // ... and change to color when @n exists and is greater than 1
+                                if (attr.n && attr.n > 1) verse.style.fill = "darkcyan";
+                            }
+                        });
+                }
+            });
+        </script>
+        <!-- The div where we are going to insert the SVG -->
+        <div id="notation" />
+    </body>
+</html>

--- a/_includes/tutorials/editorial-markup.css
+++ b/_includes/tutorials/editorial-markup.css
@@ -1,0 +1,11 @@
+html, body {
+    height: 100%;
+    width: 100%;
+  }
+  
+  g.lem {
+    fill: darkcyan;
+  }
+  g.rdg {
+    fill: crimson;
+  }

--- a/_includes/tutorials/editorial-markup.html
+++ b/_includes/tutorials/editorial-markup.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title>Interacting with editorial markup</title>
+        <!-- A stylesheet for modifying the appearance of the editorial markup -->
+        <link href="editorial-markup.css" rel="stylesheet" type="text/css" />
+        <!-- Verovio -->
+        <script src="https://www.verovio.org/javascript/develop/verovio-toolkit-wasm.js" defer></script>
+    </head>
+    <body>
+        <button id="original">Original</button>
+        <button id="contrafactum">Contrafactum</button>
+        <button id="prevPage">Previous page</button>
+        <button id="nextPage">Next page</button>
+        <div id="notation"></div>
+        <script>
+            /** 
+             Load Verovio
+            **/
+            document.addEventListener("DOMContentLoaded", (event) => {
+            verovio.module.onRuntimeInitialized = function () {
+                // This line initializes the Verovio toolkit
+                const tk = new verovio.toolkit();
+
+                // An array to keep xpath queries for selecting editorial markup
+                let appXPath = [];
+
+                // Keep a variable to the notation div id
+                let notationElement = document.getElementById("notation");
+
+                // A function that loads the file
+                function loadFile() {
+
+                    fetch("https://raw.githubusercontent.com/marenzio/marenzio.github.io/master/mei/M-04-6/M_04_6_02_Di_nettare_amoroso_ebro_la_mente.mei")
+                        // ... then receives the response and "unpacks" the MEI from it
+                        .then((response) => response.text())
+                        .then((meiXML) => {
+                        // First we set the options, including the appXPathQuery one
+                        tk.setOptions({
+                            pageWidth: document.body.clientWidth,
+                            pageHeight: document.body.clientHeight,
+                            scale: 50,
+                            scaleToPageSize: true,
+                            appXPathQuery: appXPath
+                        });
+                        // ... then we can load the data into Verovio ...
+                        tk.loadData(meiXML);
+                        // ... and generate and set the SVG for the current page ...
+                        notationElement.innerHTML = tk.renderToSVG(currentPage);
+                        });
+                    }
+
+                    // The current page, which will change when playing through the piece
+                    let currentPage = 1;
+
+                    /**
+                        Wire up the button to actually work.
+                    */
+                    const nextPageHandler = function () {
+                        currentPage = Math.min(currentPage + 1, tk.getPageCount());
+                        notationElement.innerHTML = tk.renderToSVG(currentPage);
+                    }
+
+                    const prevPageHandler = function () {
+                        currentPage = Math.max(currentPage - 1, 1);
+                        notationElement.innerHTML = tk.renderToSVG(currentPage);
+                    }
+
+                    const originalHandler = function () {
+                        appXPath = [];
+                        loadFile();
+                    }
+
+                    const contrafactumHandler = function () {
+                        appXPath = ["./rdg[@source='English']"];
+                        loadFile();
+                    }
+
+                    /**
+                        Wire up the buttons to actually work.
+                    */
+                    document.getElementById("nextPage").addEventListener("click", nextPageHandler);
+                    document.getElementById("prevPage").addEventListener("click", prevPageHandler);
+                    document.getElementById("original").addEventListener("click", originalHandler);
+                    document.getElementById("contrafactum").addEventListener("click", contrafactumHandler);
+
+                    // This line fetches the MEI file we want to render...
+                    loadFile();
+                }
+            });
+        </script>
+    </body>
+</html>

--- a/_includes/tutorials/midi.css
+++ b/_includes/tutorials/midi.css
@@ -1,0 +1,8 @@
+html, body {
+    height: 100%;
+    width: 100%;
+}
+  
+g.note.playing {
+    fill: crimson;
+}  

--- a/_includes/tutorials/midi.html
+++ b/_includes/tutorials/midi.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title>MIDI playback</title>
+        <!-- A stylesheet for modifying the appearance of the notes being played -->
+        <link href="midi.css" rel="stylesheet" type="text/css" />
+        <!-- Verovio -->
+        <script src="https://www.verovio.org/javascript/develop/verovio-toolkit-wasm.js" defer></script>
+        <!-- A JavaScript MIDI player -->
+        <script src='https://www.midijs.net/lib/midi.js'></script>
+    </head>
+    <body>
+        <button id="playMIDI">Play</button>
+        <button id="stopMIDI">Stop</button>
+        <div id="notation"></div>
+        <script>
+            /** 
+                We need to wait for the whole page to load before we try to 
+                work with Verovio.
+            **/
+            document.addEventListener("DOMContentLoaded", (event) => {
+                verovio.module.onRuntimeInitialized = function () {
+                    // This line initializes the Verovio toolkit
+                    const tk = new verovio.toolkit();
+
+                    tk.setOptions({
+                        pageWidth: document.body.clientWidth,
+                        pageHeight: document.body.clientHeight,
+                        scaleToPageSize: true,
+                    });
+
+                    // The current page, which will change when playing through the piece
+                    let currentPage = 1;
+
+                    /**
+                     The handler to start playing the file
+                    **/
+                    const playMIDIHandler = function () {
+                        // Get the MIDI file from the Verovio toolkit
+                        let base64midi = tk.renderToMIDI();
+                        // Add the data URL prefixes describing the content
+                        let midiString = 'data:audio/midi;base64,' + base64midi;
+                        // Pass it to play to MIDIjs
+                        MIDIjs.play(midiString);
+                    }
+
+                    /**
+                     The handler to stop playing the file
+                    **/
+                    const stopMIDIHandler = function () {
+                        MIDIjs.stop();
+                    }
+
+                    const midiHightlightingHandler = function (event) {
+                        // Remove the attribute 'playing' of all notes previously playing
+                        let playingNotes = document.querySelectorAll('g.note.playing');
+                        for (let playingNote of playingNotes) playingNote.classList.remove("playing");
+
+                        // Get elements at a time in milliseconds (time from the player is in seconds)
+                        let currentElements = tk.getElementsAtTime(event.time * 1000);
+
+                        if (currentElements.page == 0) return;
+
+                        if (currentElements.page != currentPage) {
+                            currentPage = currentElements.page;
+                            document.getElementById("notation").innerHTML = tk.renderToSVG(currentPage);
+                        }
+
+                        // Get all notes playing and set the class
+                        for (note of currentElements.notes) {
+                            let noteElement = document.getElementById(note);
+                            if (noteElement) noteElement.classList.add("playing");
+                        }
+                    }
+
+                    /**
+                        Wire up the buttons to actually work.
+                    */
+                    document.getElementById("playMIDI").addEventListener("click", playMIDIHandler);
+                    document.getElementById("stopMIDI").addEventListener("click", stopMIDIHandler);
+                    /**
+                     Set the function as message callback
+                    */
+                    MIDIjs.player_callback = midiHightlightingHandler;
+
+                    // This line fetches the MEI file we want to render...
+                    fetch("https://www.verovio.org/examples/downloads/Schubert_Lindenbaum.mei")
+                    // ... then receives the response and "unpacks" the MEI from it
+                    .then((response) => response.text())
+                    .then((meiXML) => {
+                        // ... then we can load the data into Verovio ...
+                        tk.loadData(meiXML);
+                        // ... and generate the SVG for the first page ...
+                        let svg = tk.renderToSVG(1);
+                        // ... and finally gets the <div> element with the ID we specified, 
+                        // and sets the content (innerHTML) to the SVG that we just generated.
+                        document.getElementById("notation").innerHTML = svg;
+                    });
+                }
+            });
+        </script>
+    </body>
+</html>

--- a/_includes/tutorials/musicxml.html
+++ b/_includes/tutorials/musicxml.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title>Convert compressed MusicXML</title>
+        <script src="https://www.verovio.org/javascript/develop/verovio-toolkit-wasm.js" defer></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.0/FileSaver.min.js"></script>
+    </head>
+    <body>
+        <button id="saveMEI">Save my MEI!</button>
+        <div id="notation"></div>
+        <script>
+            /** 
+                We need to wait for the whole page to load before we try to 
+                work with Verovio.
+            **/
+            document.addEventListener("DOMContentLoaded", (event) => {
+                verovio.module.onRuntimeInitialized = function () {
+                    // This line initializes the Verovio toolkit
+                    const tk = new verovio.toolkit();
+
+                    document.getElementById("saveMEI").addEventListener("click", (event) => {
+                        let meiContent = tk.getMEI();
+                        var myBlob = new Blob([meiContent], {type: "application/xml"});
+                        saveAs(myBlob, "meifile.mei");
+                    });
+
+                    fetch("https://www.verovio.org/examples/musicxml/Schubert_Staendchen_D.923.mxl")
+                        .then((response) => response.arrayBuffer())
+                        .then((mxlData) => {
+                            tk.loadZipDataBuffer(mxlData);
+                            let svg = tk.renderToSVG(1);
+                            document.getElementById("notation").innerHTML = svg;
+                        }).catch(e => {
+                            console.log("An error occurred when loading the file!");
+                            console.log(e);
+                        });
+                }
+            });
+        </script>
+    </body>
+</html>

--- a/_plugins/copy_tutorials.rb
+++ b/_plugins/copy_tutorials.rb
@@ -1,0 +1,10 @@
+require 'fileutils'
+
+def copy_tutorials(source, destination)
+	puts %(copy_tutorials.rb: Copying tutorial files from "#{source}" to "#{destination}")
+	FileUtils.cp_r source, destination
+end
+
+Jekyll::Hooks.register :site, :post_write do |jekyll|
+	copy_tutorials '_includes/tutorials', '_site/tutorials'
+end

--- a/scripts/toc.yaml
+++ b/scripts/toc.yaml
@@ -31,10 +31,34 @@
 "/first-steps/layout-options.html#end-of-section-3": End of Section 3
 "/first-steps/score-navigation.html": Score navigation
 "/first-steps/score-navigation.html#creating-the-controls": Creating the controls
-"/interactive-notation/": Introduction
-"/interactive-notation/working-with-css-and-svg.html": Working with CSS and SVG
-"/interactive-notation/xpath-queries.html": XPath queries
-"/interactive-notation/working-with-midi.html": Working with MIDI
+"/interactive-notation/css-and-svg.html": CSS and SVG
+"/interactive-notation/css-and-svg.html#understanding-the-structure-of-the-svg": Understanding
+  the structure of the SVG
+"/interactive-notation/css-and-svg.html#applying-css-to-the-svg": Applying CSS to
+  the SVG
+"/interactive-notation/css-and-svg.html#adjusting-the-style-programmatically": Adjusting
+  the style programmatically
+"/interactive-notation/css-and-svg.html#full-example": Full example
+"/interactive-notation/encoding-formats.html": Encoding formats
+"/interactive-notation/encoding-formats.html#saving-as-mei": Saving as MEI
+"/interactive-notation/encoding-formats.html#compressed-musicxml": Compressed MusicXML
+"/interactive-notation/encoding-formats.html#wrapping-up": Wrapping up
+"/interactive-notation/encoding-formats.html#full-example": Full example
+"/interactive-notation/playing-midi.html": Playing the MIDI output
+"/interactive-notation/playing-midi.html#add-a-midi-player": Add a MIDI player
+"/interactive-notation/playing-midi.html#highlighting-the-notes-while-playing": Highlighting
+  the notes while playing
+"/interactive-notation/playing-midi.html#full-example": Full example
+"/interactive-notation/content-selection.html": Score content selection
+"/interactive-notation/content-selection.html#selecting-parts-of-a-score": Selecting
+  parts of a score
+"/interactive-notation/content-selection.html#full-example": Full example
+"/interactive-notation/editorial-markup.html": Interacting with editorial markup
+"/interactive-notation/editorial-markup.html#selection-with-an-xpath-query": Selection
+  with an xpath query
+"/interactive-notation/editorial-markup.html#switching-between-readings": Switching
+  between readings
+"/interactive-notation/editorial-markup.html#full-example": Full example
 "/advanced-topics/": Introduction
 "/advanced-topics/internal-structure.html": Internal structure
 "/advanced-topics/internal-structure.html#layout-and-positioning": Layout and positioning


### PR DESCRIPTION
More or less copied from the tutorial given in repl.it

Sturcture: the full examples are in `_includes/tutorials/ ` (which means that the can be included in the tutorial page) are copied to the `_site` (which means the can be accessed online too)

Ex:
```md
### Full example

Open [this example](/tutorials/content-selection.html){:target="_blank"} in a new window.

``html
{% include tutorials/content-selection.html %}
``
```
Will produce
<img width="864" alt="image" src="https://user-images.githubusercontent.com/689412/206223464-8d34bd1e-3661-4c21-93f1-0e524b4780e2.png">
