### PR TITLE
Add MIDI options to toolkit reference

### DIFF
--- a/_book/05-toolkit-reference/04-toolkit-options.md
+++ b/_book/05-toolkit-reference/04-toolkit-options.md
@@ -81,6 +81,10 @@ All of the base options are short options in the command-line version of the too
 
 {% include options/4-elementMargins.md %}
 
+### Midi options
+
+{% include options/5-midi.md %}
+
 <script type="text/javascript">
 $('input:radio[name="lang"]').click(function() {
     $("span").toggleClass("lang1 lang2");


### PR DESCRIPTION
The option category MIDI was not called in toolkit options list.