### PR TITLE
Add section about VS Code

### DIFF
--- a/_book/06-installing-or-building-from-sources/01-command-line.md
+++ b/_book/06-installing-or-building-from-sources/01-command-line.md
@@ -91,10 +91,18 @@ rm -f /usr/local/bin/verovio
 rm -rf /usr/local/share/verovio
 ```
 
+#### Troubleshooting
 Occasionally there are problems with updates necessary to the `Makefile` when compiling a new version of Verovio with make. It may be necessary to clear out the automatically generated cmake files and regenerate them. To do that, run:
 
 ```bash
-rm -rf CMakeFiles CMakeCache.txt Makefile cmake_install.cmake
+rm -rf Files CMakeCache.txt Makefile cmake_install.cmake
+```
+
+Or, when using CMake 3.24 or later, you can simply run: 
+
+```bash
+cd tools
+cmake ../cmake --fresh
 ```
 
 ### Windows 10

--- a/_book/06-installing-or-building-from-sources/01-command-line.md
+++ b/_book/06-installing-or-building-from-sources/01-command-line.md
@@ -95,7 +95,7 @@ rm -rf /usr/local/share/verovio
 Occasionally there are problems with updates necessary to the `Makefile` when compiling a new version of Verovio with make. It may be necessary to clear out the automatically generated cmake files and regenerate them. To do that, run:
 
 ```bash
-rm -rf Files CMakeCache.txt Makefile cmake_install.cmake
+rm -rf CMakeFiles CMakeCache.txt Makefile cmake_install.cmake
 ```
 
 Or, when using CMake 3.24 or later, you can simply run: 

--- a/_book/06-installing-or-building-from-sources/01-command-line.md
+++ b/_book/06-installing-or-building-from-sources/01-command-line.md
@@ -138,3 +138,9 @@ By default, humdrum support is turned off in Xcode. To turn in on, you need to u
 * Go into the tools folder of Verovio
 * Execute `cmake ../cmake -DNO_PAE_SUPPORT=ON` (add `-DCMAKE_GENERATOR_PLATFORM=x64` for a x64 solution)
 * Open the resulting `Verovio.sln` with Visual Studio and build it from there
+
+### Visual Studio Code
+
+Verovio contains simple predefined build tasks in the `tasks.json` file.
+
+You can build Verovio by pressing `Ctrl+Shift+B` / `⇧⌘B` or running **Run Build Task** from the global **Terminal** menu.


### PR DESCRIPTION
This add a build instruction for VS Code. 
Also it marks the _troubleshooting_ section as such and extends it a bit.