### PR TITLE
Change deprecated exists? to exist?

### DIFF
--- a/_plugins/music-notation-examples.rb
+++ b/_plugins/music-notation-examples.rb
@@ -35,8 +35,8 @@ module Jekyll
             # The flags set here are to inform the _include/music-notation template not to actually include them
             puts svgExamples + svgFile
             puts meiExamples + meiFile
-            example['svg-example-exists'] = true unless (!File.exists?(svgExamples + svgFile))
-            example['mei-example-exists'] = true unless (!File.exists?(meiExamples + meiFile))
+            example['svg-example-exists'] = true unless (!File.exist?(svgExamples + svgFile))
+            example['mei-example-exists'] = true unless (!File.exist?(meiExamples + meiFile))
           end
         end
       end


### PR DESCRIPTION
When @wergo and I were trying to `bundle exec jekyll build`, we encountered the following error:

`/private/var/git/verovio-reference-book/_plugins/music-notation-examples.rb:38:in 'block (2 levels) in Jekyll::MusicNotationExamples#generate': undefined method 'exists?' for class File (NoMethodError)`

It turns out that `exists?` was deprecated in favour of `exist?` in Ruby v.3.2.0; see e.g. here: https://stackoverflow.com/questions/14351272/undefined-method-exists-for-fileclass-nomethoderror

This PR updates the two instances of `exists?` accordingly, making the build process work again.